### PR TITLE
Addon major version revision. New JSON Importer.

### DIFF
--- a/io_scene_gr2/__init__.py
+++ b/io_scene_gr2/__init__.py
@@ -1,12 +1,12 @@
 # <pep8 compliant>
 
 bl_info = {
-    "name": "Star Wars: The Old Republic (.gr2)",
-    "author": "Darth Atroxa, SWTOR Slicers",
-    "version": (4, 2, 1),
+    "name": "SWTOR: Import/Export Tools",
+    "author": "Darth Atroxa, Crunch, SWTOR Slicers",
+    "version": (5, 0, 2),
     "blender": (3, 6, 0),
     "location": "File > Import-Export",
-    "description": "Import-Export SWTOR skeleton, or model with bone weights, UV's and materials",
+    "description": "Import SWTOR GR2, JBA, CLO Files, and Export SWTOR Compatible GR2 Files",
     "support": 'COMMUNITY',
     "category": "Import-Export",
 }
@@ -24,7 +24,7 @@ from bpy.app.handlers import depsgraph_update_post
 from bpy.props import FloatVectorProperty
 from bpy.types import Context, KeyMap, Menu, PropertyGroup
 
-from .addon_prefs import Prefs, GR2PREFS_MT_presets_menu, GR2PREFS_OT_set_preset
+from .addon_prefs import Prefs
 
 from .ops.export_gr2             import ExportGR2
 from .ops.export_gr2_32          import ExportGR2_32
@@ -88,7 +88,7 @@ def _import_jba(self, _context):
 
 def _import_cha(self, _context):
     # type: (Menu, Context) -> None
-    self.layout.operator(ImportCHA.bl_idname, text="SWTOR PC/NPCs (paths.json) - DO NOT USE!  Read Tooltip")
+    self.layout.operator(ImportCHA.bl_idname, text="SWTOR NPC/Character (Jedipedia .json)")
 
 def _import_clo(self, _context):
     # type: (Menu, Context) -> None
@@ -110,7 +110,7 @@ class BoneBounds(PropertyGroup):
 
 
 classes = (
-    Prefs, GR2PREFS_MT_presets_menu, GR2PREFS_OT_set_preset,
+    Prefs,
     BoneBounds,
     ExportGR2,
     ExportGR2_32,

--- a/io_scene_gr2/addon_prefs.py
+++ b/io_scene_gr2/addon_prefs.py
@@ -44,13 +44,48 @@ class Prefs(bpy.types.AddonPreferences):
         soft_max = 10.0,
         step = 10,
         precision = 2,
-        default=1.0,
+        default=10.0,
         update=update_jba_scale,
     )
     
     gr2_apply_axis_conversion: bpy.props.BoolProperty(
         name="Apply Axis Conversion",
         description="Permanently converts the imported object\nto Blender's 'Z-is-Up' coordinate system\nby 'applying' a x=90º rotation.\n\nSWTOR's coordinate system is 'Y-is-up' vs. Blender's 'Z-is-up'.\nTo compensate for that in a reversible manner, this importer\nnormally sets the object's rotation to X=90º at the Object level.\n\nAs this can be a nuisance outside a modding use case,\nthis option applies it at the Mesh level, instead",
+        default=False,
+    )
+
+
+    # NPC/Character (.json) import ones:
+
+    swtor_resources_dir: bpy.props.StringProperty(
+        name="Resources Directory",
+        description="Local folder containing your SWTOR assets extraction, mirroring the game's\nown layout directly (this folder should directly contain an 'art' subfolder).\n\nUsed by the NPC/Character (.json) importer to read .gr2/.mat/.dds files\ndirectly from here, without a separate asset-gathering/copying step.",
+        subtype='DIR_PATH',
+        default="",
+    )
+    
+    swtor_legacy_resources_dir: bpy.props.StringProperty(
+        name="Legacy Resources Directory",
+        description="Local folder containing your Legacy SWTOR assets extraction, mirroring the game's\nown layout directly (this folder should directly contain an 'art' subfolder).\n\nUsed by the NPC/Character (.json) importer to read .gr2/.mat/.dds files\ndirectly from here, without a separate asset-gathering/copying step.",
+        subtype='DIR_PATH',
+        default="",
+    )
+
+    gr2_import_skeleton_default: bpy.props.BoolProperty(
+        name="Import Skeleton By Default",
+        description="Default state of the NPC/Character importer's 'Import Skeleton' option.\n\nCan still be switched per-import in the importer's own panel",
+        default=False,
+    )
+
+    gr2_bind_to_skeleton_default: bpy.props.BoolProperty(
+        name="Bind To Skeleton By Default",
+        description="Default state of the NPC/Character importer's 'Bind To Skeleton' option.\n\nCan still be switched per-import in the importer's own panel",
+        default=False,
+    )
+
+    gr2_append_character_name_to_collections_default: bpy.props.BoolProperty(
+        name="Append Character Name to Collections By Default",
+        description="Default state of the NPC/Character importer's 'Append Character Name to Collections' option.\n\nCan still be switched per-import in the importer's own panel",
         default=False,
     )
 
@@ -75,32 +110,26 @@ class Prefs(bpy.types.AddonPreferences):
         
         layout = self.layout
         
-        split = layout.split(factor=0.5)
-        
-        col=split.column(align=True)
-        col.scale_y = 0.80
+        box = layout.box().column(align=True)
+        box.label(text="Common Directories:")
+        box.scale_y = 0.90
+        box.prop(self, 'swtor_resources_dir', text="Resources Directory")
+        box.prop(self, 'swtor_legacy_resources_dir', text="Legacy Resources Directory")
 
-        col.label(text="You can set your preferred settings for this")
-        col.label(text="Add-on's importers and exporters here.")
-        col.label(text="(They can be modified on the fly, too).")
+        box = layout.box().column(align=True)
+        box.label(text="NPC/CHARACTER (.JSON) IMPORT SETTINGS:")
+        box.scale_y = 0.90
+        row = box.row(align=True)
+        row.prop(self, 'gr2_import_skeleton_default', text="Import Skeleton By Default")
+        row.prop(self, 'gr2_bind_to_skeleton_default', text="Bind To Skeleton By Default")
+        box.prop(self, 'gr2_append_character_name_to_collections_default', text="Append Character Name to Collections By Default")
 
-        col=split.column(align=True)
-        col.scale_y = 0.80
-        col.label(text="This Menu provides sensible settings for")
-        col.label(text="most typical tasks as a starting point.")
-        col.menu('import_mesh.gr2_presets', text="QUICK PRESETS MENU",)
-
-
-        col = layout.column()
-        col.scale_y = 0.70
-        col.label(text="BEFORE CHANGING ANY SETTING, CAREFULLY CONSIDER HOW THEY MIGHT AFFECT")
-        col.label(text="YOUR WORKFLOW!!!  Use the 'NEUTRAL' preset to return to the default settings.")
-        
         split = layout.split(factor=0.5)
         split_left = split
         split_right = split
         
-        boxcol = split_left.box().column(align=True, heading=".GR2 OBJECTS IMPORT SETTINGS:")
+        boxcol = split_left.box().column(align=True)
+        boxcol.label(text=".GR2 OBJECTS IMPORT SETTINGS:")
         boxcol.scale_y = 0.90
         boxcol.prop(self,'gr2_import_collision')
         boxcol.prop(self,'gr2_name_as_filename', text="Name Imported Objects As Filenames")
@@ -111,7 +140,8 @@ class Prefs(bpy.types.AddonPreferences):
         slider_split.label()
         slider_split.prop(self,'gr2_scale_factor', text="Scale factor")
         
-        boxcol = split_right.box().column(align=True, heading=".JBA ANIMATIONS IMPORT SETTINGS:")
+        boxcol = split_right.box().column(align=True)
+        boxcol.label(text=".JBA ANIMATIONS IMPORT SETTINGS:")
         boxcol.scale_y = 0.90
         boxcol.prop(self,'jba_ignore_facial_bones', text="Ignore Facial Bones' Translation Data")
         boxcol.prop(self,'jba_delete_180')
@@ -120,101 +150,14 @@ class Prefs(bpy.types.AddonPreferences):
         boxcol.label(text="use all the applicable .gr2 Object settings.")
 
 
-class GR2PREFS_MT_presets_menu(bpy.types.Menu):
-    bl_idname = "import_mesh.gr2_presets"
-    bl_label = "Quick Presets Menu"
-    bl_description = "Easy Presets for the SWTOR Importers/Exporters:\nthey adjust the settings to sensible values depending on our goals.\n\nBEFORE CHOOSING A PRESET, CAREFULLY CONSIDER\nHOW IT MIGHT AFFECT YOUR WORKFLOW!"
-        
-    
-    def draw(self, context):
-        layout = self.layout
-        
-        layout.operator('import_mesh.gr2_set_preset', text="NEUTRAL:  replicates the default settings of older versions of this Add-on"              ).preset = 'NEUTRAL'
-
-        layout.operator('import_mesh.gr2_set_preset', text="PORTING:  for porting assets to other Game Engines and VR apps (send us feedback!)."                   ).preset = 'PORTING'
-
-        layout.operator('import_mesh.gr2_set_preset', text="BLENDER:  for creating art directly in Blender or in combination with other 3D Art apps.").preset = 'BLENDER'
-        
-        # layout.operator('import_mesh.gr2_set_preset', text="MODDING:  for modifying SWTOR assets in such a manner that they can be reinserted back." ).preset = 'MODDING'
-
-
-class GR2PREFS_OT_set_preset(bpy.types.Operator):
-    bl_idname = "import_mesh.gr2_set_preset"
-    bl_label = "SW:TOR Importers' Preferences Presets Menu"
-    bl_options = {'REGISTER', "UNDO"}
-    bl_description = "Easy Presets for the SW:TOR Importers"
-
-    preset: bpy.props.StringProperty(
-        name=".gr2 Add-on's Presets",
-        default="BLENDER",)
-
-    def execute(self, context):
-
-        prefs = context.preferences.addons["io_scene_gr2"].preferences
-        
-        if self.preset == 'BLENDER' or self.options is None:
-
-            prefs.gr2_import_collision    = False
-            prefs.gr2_name_as_filename    = True
-            prefs.gr2_scale_object        = True
-            prefs.gr2_scale_factor        = 10.0
-            prefs.gr2_apply_axis_conversion  = True
-
-            prefs.jba_ignore_facial_bones = True
-            prefs.jba_delete_180          = True
-
-        if self.preset == 'PORTING':
-
-            prefs.gr2_import_collision    = False
-            prefs.gr2_name_as_filename    = True
-            prefs.gr2_scale_object        = False
-            prefs.gr2_scale_factor        = 1.0
-            prefs.gr2_apply_axis_conversion  = True
-
-            # SWTOR animations aren't typically
-            # used here. Still…
-            prefs.jba_ignore_facial_bones = True
-            prefs.jba_delete_180          = False
-        
-        if self.preset == 'MODDING':
-
-            prefs.gr2_import_collision    = True
-            prefs.gr2_name_as_filename    = False
-            prefs.gr2_scale_object        = False
-            prefs.gr2_scale_factor        = 1.0
-            prefs.gr2_apply_axis_conversion  = False
-
-            # SWTOR animations aren't typically
-            # used here. Still…
-            prefs.jba_ignore_facial_bones = True
-            prefs.jba_delete_180          = False
-
-        if self.preset == 'NEUTRAL':
-
-            prefs.gr2_import_collision    = False
-            prefs.gr2_name_as_filename    = False
-            prefs.gr2_scale_object        = False
-            prefs.gr2_scale_factor        = 1.0
-            prefs.gr2_apply_axis_conversion  = False
-
-            prefs.jba_ignore_facial_bones = True
-            prefs.jba_delete_180          = False
-           
-        return {"FINISHED"}
-    
-    
 
 # Registrations
 
 def register():
     bpy.utils.register_class(Prefs)
-    bpy.utils.register_class(GR2PREFS_MT_presets_menu)
-    bpy.utils.register_class(GR2PREFS_OT_set_preset)
 
 
 def unregister():
-    bpy.utils.unregister_class(GR2PREFS_OT_set_preset)
-    bpy.utils.unregister_class(GR2PREFS_MT_presets_menu)
     bpy.utils.unregister_class(Prefs)
 
 if __name__ == "__main__":

--- a/io_scene_gr2/ops/import_cha.py
+++ b/io_scene_gr2/ops/import_cha.py
@@ -1,972 +1,1247 @@
 # <pep8 compliant>
 
 """
-This script imports Star Wars: The Old Republic characters into Blender.
+Merged SWTOR NPC/Character importer created by Crunch.
 
-Usage:
-Run this script from "File->Import" menu and then load the desired JSON file.
+Replaces the old import_cha.py (IO Scene GR2) + char_character_assembler.py
+(ZG_Tools) split. Reads directly from a local "resources" folder (mirroring
+the game's extracted asset layout) instead of copying assets into a
+per-character folder first.
+
+Targets Jedipedia.net's json export format exclusively.
+No support for older TORC exports with none planned.
 """
 
 import json
-from re import A
-import xml.etree.ElementTree as ET  # for parsing .mat files looking for directionMaps
-import os
-from typing import Any, Dict, List, Optional, Set, Tuple
-import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 import bpy
-from bpy import app
-from bpy.props import BoolProperty, FloatProperty, CollectionProperty, StringProperty
-from bpy.types import Context, Operator, OperatorFileListElement
-from bpy_extras.io_utils import ImportHelper
+import bmesh
+from mathutils import Vector, Matrix
+
+from .import_gr2 import load as ImportGR2_load
+from ..types.shared import job_results
 
 
-from .import_gr2 import load as ImportGR2_load  # .gr2 importing function used by this module 
+# ---------------------------------------------------------------------------
+# Path resolution (spec §4)
+# ---------------------------------------------------------------------------
 
-
-from ..utils.string import path_format, path_split
-
-from ..types.shared import job_results  # add-on-wide global-like dict
-
-
-
-# Detect Blender version
-major, minor, _ = bpy.app.version
-blender_version = float(f"{major}.{minor}")
-
-
-
-
-class ImportCHA(Operator):
+def resolve_resource_path(resources_root, relative_path):
+    # type: (str, Optional[str]) -> Optional[str]
     """
-    Import from JSON file format (.json)
-    
-    Produces a file browser for manually
-    selecting a TORCommunity.com-formatted
-    paths.json file describing a SWTOR character
-    and their gear.
+    Resolves a Jedipedia json path (e.g. "/art/dynamic/head/model/x.gr2")
+    against a local resources root folder that contains an "art" subfolder
+    directly, mirroring the game's own asset layout.
+
+    Defensively strips:
+    - a single leading slash or backslash
+    - a redundant leading "resources" path segment, in case a path
+      includes one (historically seen on the old meta.skeletonModel
+      field, before skeleton resolution moved to the .dyc-based lookup
+      in import_skeleton() -- kept as a general safety net)
+
+    Returns None if relative_path is falsy, so callers can skip absent
+    optional paths without extra checks.
     """
-    bl_idname = "import_mesh.gr2_json"  # DO NOT CHANGE
-    bl_label = "Import SWTOR (.json)"
-    bl_description = "UNLESS TRYING TO DIAGNOSE AN ISSUE, USE THE\nZG SWTOR TOOLS ADD-ON'S CHARACTER ASSEMBLER\nOR THE JZ SWTOR TOOLS ADD-ON INSTEAD.\n\nTHIS IMPORTER WILL FAIL IF THE PC/NPC FILES\nHAVEN'T BEEN GATHERED BY OTHER TOOLS FIRST.\n\n(The ZG SWTOR Tools' Character Assembler\ncopies the game assets listed in the .json file into\nthe PC/NPC's folder, and then calls this importer.\nWe keep this import menu option to diagnose errors)\n\n---\n\nImport a 'paths.json' file inside a character folder generated\nby TORCommunity.com's Character Designer\nor its NPC database's 3D Viewers.\n\n• The folder needs to have been filled with the requisite assets\n   by a Character Assembler tool or manually."
-    bl_options = {'UNDO'}
+    if not relative_path:
+        return None
+
+    # Normalize to forward slashes regardless of which slash style the
+    # json used, so splitting is consistent.
+    normalized = relative_path.replace("\\", "/").lstrip("/")
+
+    parts = normalized.split("/")
+    if parts and parts[0].lower() == "resources":
+        parts = parts[1:]
+
+    return str(Path(resources_root, *parts))
 
 
+# ---------------------------------------------------------------------------
+# JSON parsing (spec §3, §5)
+# ---------------------------------------------------------------------------
 
-    # File Browser properties
-    
-    # This class used to be based on ImportHelper
-    # but we now use invoke() to be able to use
-    # the Add-on's Preferences settings when
-    # called from the Import menu and launching
-    # a File Browser.
-    
-    # filepath is explicitly declared because
-    # omitting ImportHelper omits it, too.
-    # invoke() handles what to do if it is
-    # filled as a param in an external call.
-    
-    filepath: StringProperty(subtype='FILE_PATH')
-    
-    if app.version < (2, 82, 0):
-        directory = StringProperty(subtype='DIR_PATH')
-    else:
-        directory: StringProperty(subtype='DIR_PATH')
+def read(filepath):
+    # type: (str) -> Tuple[Dict[str, Any], Dict[str, List[Dict]], List[Dict]]
+    """
+    Parses a Jedipedia-formatted NPC/PC json file.
 
-    filename_ext = ".json"
+    This is a pure parser: it doesn't touch the resources folder, doesn't
+    validate that the file "looks like" a character file, and doesn't
+    raise on a missing "meta" entry (current live Jedipedia exports don't
+    emit one yet) — callers decide how to handle those cases.
 
-    files: CollectionProperty(
-        name="File Path",
-        description="File path used for importing the JSON file",
-        type=OperatorFileListElement,
-    )
+    Returns:
+        meta:
+            Dict of the parsed "meta" entry's fields (charType, charName,
+            nppPath, BodyType, errors). Empty dict if no "meta" entry is
+            present. BodyType drives skeleton resolution -- see
+            import_skeleton()'s docstring for how.
 
-    filter_glob: StringProperty(
-        default="*.json",
-        options={'HIDDEN'}
-    )
+        slots:
+            Dict mapping slotName -> ordered list of raw entry dicts, in
+            the order they appeared in the file. A slotName with more
+            than one entry represents multiple import variants (spec §5)
+            — e.g. two "head" entries for two alternate head sculpts.
+            The reserved "skinMats" slotName is excluded here; see
+            skin_mats below.
 
-
-
-    # Importing parameters' properties.
-    # THEY AREN'T SPECIFIC TO THE CHARACTER ASSEMBLER BUT
-    # TO THE .GR2 OBJECTS IMPORTER WORKING UNDER THE HOOD.
-    #
-    # When being called from the Import menu, invoke()
-    # will copy the Add-on's prefs settings to them.
-    #
-    # When called from external code, filled arguments
-    # will override current prefs settings.
-
-    import_collision: BoolProperty(
-        name="Import Collision Mesh",
-        description="Imports objects' collision boundary mesh if present in the files\n(it can be of use when exporting models to other apps and game engines)",
-        default=False,
-    )
-
-    npc_uses_skin: bpy.props.BoolProperty(
-        name="NPC Gear Uses Skin ",
-        description="When importing a non-Creature-type NPC, assume that any 2nd. Material Slots\nin armor or clothes are skin. If unticked, use a garment material instead.\n\nMOST NPC GEAR LACK SECOND MATERIALS, ANYWAY.\nTypical case actually using this checkbox: cantina dancers.\n\nIn mixed use cases, the Material Slots' assignments can be easily corrected\nmanually. Skin materials are always created, no matter if not in use.\n\n(TORCommunity.com's non-Creature NPC database exports don't include\n'materialSkinIndex' data indicating whether a piece of garment with\ntwo material slots uses skin or garment for the 2nd one. Hence this\ncheckbox)",
-        default = True,
-        # options={'HIDDEN'}
-    )
-
-    name_as_filename: BoolProperty(
-        name="Name As Filename",
-        description="Names the imported Blender objects with their filenames instead of their\ninternal 'art names' (the object's mesh data always keeps the 'art name').\n\n.gr2 objects' internal 'art names' typically match their files' names,\nbut sometimes they difer, which can break some tools and workflows.\n\nIn case of multiple mesh files (containing a main object plus secondary ones\nand / or Engine Objects such as Colliders), only the main object is renamed",
-        default=True,
-    )
-
-    use_modernization: BoolProperty(
-        name="Use Modernized Assets",
-        description="Uses the texture maps stored in a character's folder's 'materials_modernization' subfolder\ninstead of the ones in the plain 'materials' one",
-        default=False,
-    )
-
-    apply_axis_conversion: BoolProperty(
-        name="Axis Conversion",
-        description="Permanently converts the Character's imported object to Blender's 'Z-is-Up' coordinate system\nby 'applying' a x=90º rotation.\n\nSWTOR's coordinate system is 'Y-is-up' vs. Blender's 'Z-is-up'.\nTo compensate for that in a reversible manner, this importer\nnormally sets the object's rotation to X=90º at the Object level.\n\nAs this can be a nuisance outside a modding use case,\nthis option applies it at the Mesh level, instead",
-        default=False,
-    )
-
-    scale_object: BoolProperty(
-        name="Scale Object",
-        description="Scales Characters' objects and armatures\nat the Mesh level.\n\nSWTOR sizes objects in decimeters, while Blender defaults to meters.\nThis mismatch, while innocuous, is an obstacle when doing physics\nsimulations, automatic weighting from bones, or other processes\nwhere Blender requires real world-like sizes to succeed",
-        default=False,
-    )
-
-    scale_factor: FloatProperty(
-        name="Scale factor",
-        description="Recommended values are:\n\n- 10 for simplicity (characters are superhero-like tall, over 2 m.).\n- Around 8 for accuracy (characters show more realistic heights).\n\nRemember that, if binding to a skeleton later on, the skeleton\nmust match the scale of the objects to work correctly (which\ncan be done on import, or manually afterwards)",
-        min = 1.0,
-        max = 100.0,
-        soft_min = 1.0,
-        soft_max = 10.0,
-        step = 10,
-        precision = 2,
-        default=1.0,
-    )
-
-    enforce_neutral_settings: BoolProperty(
-        name="Enforce Neutral Settings",
-        description="Temporarily overrides the settings of the .gr2 Importer that\nthis Character Importer uses with those of older versions\nfor compatibility with similarly imported assets",
-        options={'HIDDEN'},
-        default=False,
-    )
-
-    job_results_rich: BoolProperty(
-        name="Rich results Info",
-        description="For easier interaction with third party code, this add-on fills 'bpy.context.scene.io_scene_gr2_last_job'\nwith info about its most recent job (imported objects's names) in .json format.\nSet to Rich, it provides additional data such as their relationships to filenames",
-        options={'HIDDEN'},
-        default=False,
-    )
-
-    job_results_accumulate: BoolProperty(
-        name="Accumulate Jobs' Results Info between ImportGR2 calls",
-        description="By default, .gr2 import requests will clear the information about previous ones.\nThis option lets them accumulate, needed for cases such as a Character Import where\nImportGR2 is called several times in succession",
-        options={'HIDDEN'},
-        default=True,
-    )
-
-
-
-    def invoke(self, context, event):
-        # To be able to set the class' properties to the values in the
-        # Add-on's preferences and show them in the File Browser's options,
-        # we use an Invoke function instead of directly using ImportHelper in
-        # the class definition, to be able to put there the required code.              
-        
-        prefs = context.preferences.addons["io_scene_gr2"].preferences
-        
-        self.import_collision           = prefs.gr2_import_collision
-        self.name_as_filename           = prefs.gr2_name_as_filename
-        self.use_modernization          = False
-        self.apply_axis_conversion      = prefs.gr2_apply_axis_conversion
-        self.scale_object               = prefs.gr2_scale_object
-        self.scale_factor               = prefs.gr2_scale_factor
-        self.enforce_neutral_settings   = False
-        self.job_results_rich           = False
-        self.job_results_accumulate     = True
-        self.npc_uses_skin              = True
-
-
-        # Handling of filepath in case of being
-        # filled as a param in an external call.
-        if not self.filepath:
-            context.window_manager.fileselect_add(self)
-            return {'RUNNING_MODAL'}
-        else:
-            return self.execute(context)        
-
-
-    def execute(self, context):
-        # type: (Context) -> Set[str]
-
-        bpy.context.window.cursor_set("WAIT")
-
-        # Clear job_results data before starting a job
-        job_results['objs_names'] = []
-        job_results['files_objs_names'] = {}
-        job_results['job_origin'] = self.bl_idname
-            
-            
-        paths = [os.path.join(self.directory, file.name) for file in self.files]
-
-        if not paths:
-            paths.append(self.filepath)
-
-        # Clear filebrowser-related properties now
-        # that they have been read and have no more
-        # use so that they don't persist if the class
-        # breaks before finishing its execution
-        # (it makes debugging difficult).
-        self.files.clear()
-        self.filepath = ""
-
-        for path in paths:
-            if not load(self, context, path):
-                return {'CANCELLED'}
-
-
-        bpy.context.scene.io_scene_gr2_last_job = json.dumps(job_results)
-
-        bpy.context.window.cursor_set("DEFAULT")
-
-        return {'FINISHED'}
-
-
-_eye_mat_info = None
-
-
-def read(self, filepath):
-    # type: (str) -> Tuple[List, Optional[Dict]]
-    '''
-    Parses a TORCommunity.com's Character Designer-formatted .json file
-    returning objects and materials data to process
-    '''
-    with open(filepath) as file:
+        skin_mats:
+            List of {"slot_name": ..., "mat_info": ...} dicts drawn from
+            the "skinMats" entry's materialInfo.mats, flattened for easy
+            lookup later (spec §6's SkinB heuristic). Empty list if the
+            "skinMats" entry is absent or has no mats.
+    """
+    with open(filepath, encoding="utf-8") as file:
         data: List[Dict[str, Any]] = json.load(file)
 
-    parsed_objects = []
-    skin_materials = None
-
-    global _eye_mat_info
+    meta: Dict[str, Any] = {}
+    slots: Dict[str, List[Dict]] = {}
+    skin_mats: List[Dict] = []
 
     for entry in data:
-        if "slotName" not in entry:
-            # We are toyng with adding additional info elements
-            # such as skeleton filepaths, in-game names, etc.
-            # This lets the importer bypass them instead of breaking.
+        slot_name = entry.get("slotName")
+        if not slot_name:
+            # Forward-compat: entries we don't recognize (yet) are
+            # skipped rather than breaking the importer.
             continue
-        elif entry["slotName"] == "skinMats":
-            to_push = {"slot_name": "skinMats", "mats": []}
 
-            for mat in entry["materialInfo"]["mats"]:
-                slot_name = mat["slotName"]
-                mat_info = mat["materialInfo"]
-                dds_dict = mat["ddsPaths"]
-                mat_info["ddsPaths"] = dds_dict
-                mat_info["otherValues"] = mat["otherValues"]
+        if slot_name == "meta":
+            meta = {
+                "charType": entry.get("charType"),
+                "charName": entry.get("charName"),
+                "nppPath": entry.get("nppPath"),
+                "BodyType": entry.get("BodyType"),
+                "errors": entry.get("errors", []),
+            }
+            continue
 
-                for key in mat_info["ddsPaths"]:
-                    tex = dds_dict[key][dds_dict[key].rfind('/'):]
-                    # if dds_dict[key] == "/.dds" or dds_dict[key] == ".dds":
-                    #     tex = "/black.dds"
+        if slot_name == "skinMats":
+            mats = entry.get("materialInfo", {}).get("mats", [])
+            for mat in mats:
+                # The source shape spreads matPath (inside "materialInfo"),
+                # "ddsPaths" and "otherValues" across three separate keys
+                # on the same mat dict. Consolidate them into a single
+                # mat_info dict shaped the same way an ordinary slot
+                # entry's materialInfo is, so downstream code (§6) can
+                # treat skin_mats entries and ordinary slot mat_infos
+                # uniformly.
+                mat_info = dict(mat.get("materialInfo", {}))
+                mat_info["ddsPaths"] = mat.get("ddsPaths", {})
+                mat_info["otherValues"] = mat.get("otherValues", {})
+                skin_mats.append({
+                    "slot_name": mat.get("slotName"),
+                    "mat_info": mat_info,
+                })
+            continue
 
-                    if self.use_modernization:
-                        mat_info["ddsPaths"][key] = \
-                            path_format(filepath,
-                                        f"/materials_modernization/skinMats/{slot_name}"
-                                        f"{tex}")
-                    else:
-                        mat_info["ddsPaths"][key] = \
-                            path_format(filepath,
-                                        f"/materials/skinMats/{slot_name}"
-                                        f"{tex}")
+        slots.setdefault(slot_name, []).append(entry)
 
-                to_push["mats"].append({"slot_name": slot_name, "mat_info": mat_info})
+    return meta, slots, skin_mats
 
-            skin_materials = to_push
+
+# ---------------------------------------------------------------------------
+# Material building (spec §6)
+# ---------------------------------------------------------------------------
+
+def _load_or_get_image(resources_root, relative_path):
+    """
+    Loads a .dds texture from the resources root, reusing an already-loaded
+    Blender image with the same filename if one exists (mirrors the
+    dedup-by-basename convention the original importer used for images --
+    distinct from the new dedup-by-.mat-filename convention used for
+    materials themselves, see get_or_create_material()).
+    """
+    path = resolve_resource_path(resources_root, relative_path)
+    if not path:
+        return None
+    name = Path(path).name
+    existing = bpy.data.images.get(name)
+    if existing:
+        return existing
+    return bpy.data.images.load(path)
+
+
+def _set_palette(node, other_values, index, include_metallic_specular):
+    """Populates a HeroEngine shader node's palette<index>_* properties."""
+    prefix = "palette%d" % index
+    other_palette = other_values[prefix]
+    setattr(node, prefix + "_hue", float(other_palette[0]))
+    setattr(node, prefix + "_saturation", float(other_palette[1]))
+    setattr(node, prefix + "_brightness", float(other_palette[2]))
+    setattr(node, prefix + "_contrast", float(other_palette[3]))
+
+    specular = other_values[prefix + "Specular"]
+    setattr(node, prefix + "_specular", [
+        float(specular[0]), float(specular[1]), float(specular[2]), 1.0,
+    ])
+
+    if include_metallic_specular:
+        metallic_specular = other_values[prefix + "MetallicSpecular"]
+        setattr(node, prefix + "_metallic_specular", [
+            float(metallic_specular[0]),
+            float(metallic_specular[1]),
+            float(metallic_specular[2]),
+            1.0,
+        ])
+
+
+# Per-derived-type configuration, replacing the original's per-branch node
+# wiring (largely copy-pasted across ~700 lines) with a single data-driven
+# function. Each "maps" tuple is (json ddsPaths key, shader node property,
+# required); required maps are read unconditionally -- same as the
+# original, a missing required key raises -- optional maps are only read
+# if present. Each "palettes" tuple is (palette index, include a
+# metallic_specular value too?).
+DERIVED_CONFIGS = {
+    "Creature": {
+        "shader_derived": "CREATURE",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+            ("paletteMaskMap", "paletteMaskMap", True),
+            ("directionMap", "directionMap", False),
+        ],
+        "palettes": [],
+        "flesh": True,
+    },
+    "Eye": {
+        "shader_derived": "EYE",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+            ("paletteMap", "paletteMap", True),
+            ("paletteMaskMap", "paletteMaskMap", True),
+        ],
+        "palettes": [(1, False)],
+        "flesh": False,
+    },
+    "Garment": {
+        "shader_derived": "GARMENT",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+            ("paletteMap", "paletteMap", True),
+            ("paletteMaskMap", "paletteMaskMap", True),
+        ],
+        "palettes": [(1, True), (2, True)],
+        "flesh": False,
+    },
+    "HairC": {
+        "shader_derived": "HAIRC",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+            ("paletteMap", "paletteMap", True),
+            ("paletteMaskMap", "paletteMaskMap", True),
+            ("directionMap", "directionMap", True),
+        ],
+        "palettes": [(1, True)],
+        "flesh": False,
+    },
+    "SkinB": {
+        "shader_derived": "SKINB",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+            ("paletteMap", "paletteMap", True),
+            ("paletteMaskMap", "paletteMaskMap", True),
+            ("ageMap", "ageMap", False),
+            ("complexionMap", "complexionMap", False),
+            ("facepaintMap", "facepaintMap", False),
+        ],
+        "palettes": [(1, True)],
+        "flesh": True,
+    },
+    "Uber": {
+        "shader_derived": "UBER",
+        "maps": [
+            ("diffuseMap", "diffuseMap", True),
+            ("rotationMap", "rotationMap", True),
+            ("glossMap", "glossMap", True),
+        ],
+        "palettes": [],
+        "flesh": False,
+    },
+}
+DERIVED_CONFIGS["GarmentScrolling"] = DERIVED_CONFIGS["Garment"]
+
+
+def _has_hero_engine_node(material):
+    """
+    True if this material already has a ShaderNodeHeroEngine node -- i.e.
+    it was actually built by get_or_create_material() at some point,
+    as opposed to merely existing under this name.
+    """
+    if not material.use_nodes or material.node_tree is None:
+        return False
+    return any(node.bl_idname == "ShaderNodeHeroEngine" for node in material.node_tree.nodes)
+
+
+def get_or_create_material(resources_root, mat_name, derived, mat_info):
+    # type: (str, str, str, Dict[str, Any]) -> Any
+    """
+    Returns a Blender material for the given governing .mat data, (re)
+    building its node graph only if it doesn't already have one.
+
+    mat_name is the .mat file's own basename, extension stripped (spec
+    §6) -- e.g. "hair_twilek_non_a08_v02" -- replacing the original's
+    "{idx} {slotName}{derived}" naming. Lookup is by name, so identical
+    .mat files reused across slots or separate NPC imports collapse into
+    one shared material automatically.
+
+    Dedup is NOT a bare bpy.data.materials.get(mat_name) existence check:
+    import_gr2.py's own low-level .gr2 reader unconditionally creates a
+    default-BSDF placeholder material for every material name embedded
+    *inside* the .gr2 file itself (see its build()'s "NOTE: Create
+    Materials" step) -- entirely independent of this json-driven code.
+    SWTOR .gr2 files can embed a material name that happens to exactly
+    match a real .mat file's basename (confirmed real case:
+    "boot_dancer01_light_ge_a21dancer01_f"), which would collide with
+    our own naming/dedup convention. So existence alone isn't a signal
+    that a material was actually already built by this function -- only
+    the presence of our own ShaderNodeHeroEngine node is. If a same-named
+    material exists but wasn't built by us, its node graph is rebuilt
+    from scratch (rather than ever creating a second, differently-
+    suffixed material for the same logical .mat).
+    """
+    new_mat = bpy.data.materials.get(mat_name)
+    if new_mat is not None and _has_hero_engine_node(new_mat):
+        return new_mat
+
+    if new_mat is None:
+        new_mat = bpy.data.materials.new(mat_name)
+
+    # "HighQualityCharacter" is an older/alternate name occasionally seen
+    # for what is otherwise a Creature material.
+    derived = "Creature" if derived == "HighQualityCharacter" else derived
+
+    config = DERIVED_CONFIGS.get(derived)
+    if config is None:
+        raise ValueError("Unrecognized derived material type: %r" % (derived,))
+
+    other_values = mat_info.get("otherValues", {})
+    dds_paths = mat_info.get("ddsPaths", {})
+
+    new_mat.use_nodes = True
+
+    # Clear every existing node (not just the default Principled BSDF --
+    # this material may be a gr2-created placeholder we're repurposing,
+    # see docstring above) and rebuild from scratch.
+    for nd in list(new_mat.node_tree.nodes):
+        new_mat.node_tree.nodes.remove(nd)
+
+    node = new_mat.node_tree.nodes.new(type="ShaderNodeHeroEngine")
+    node.location = (0.0, 300.0)
+    output = new_mat.node_tree.nodes.new(type="ShaderNodeOutputMaterial")
+    output.location = (300.0, 300.0)
+    new_mat.node_tree.links.new(node.outputs["Shader"], output.inputs["Surface"])
+
+    node.derived = config["shader_derived"]
+
+    # Alpha / transparency: unified across every derived type (confirmed:
+    # Blender 4.2 LTS/4.5 LTS only, so no pre-4.2 blend_method branch is
+    # needed, and Creature no longer needs special-cased handling).
+    new_mat.alpha_threshold = node.alpha_test_value = 0.5
+    new_mat.show_transparent_back = False
+    node.alpha_mode = 'CLIP'
+    new_mat.surface_render_method = "DITHERED"
+
+    for json_key, node_attr, required in config["maps"]:
+        if required or json_key in dds_paths:
+            image = _load_or_get_image(resources_root, dds_paths[json_key])
+            setattr(node, node_attr, image)
+
+    for palette_index, include_metallic_specular in config["palettes"]:
+        _set_palette(node, other_values, palette_index, include_metallic_specular)
+
+    if config["flesh"]:
+        node.flesh_brightness = float(other_values["fleshBrightness"])
+        flush = other_values["flush"]
+        node.flush_tone = [float(flush[0]), float(flush[1]), float(flush[2]), 1.0]
+
+    return new_mat
+
+
+# ---------------------------------------------------------------------------
+# Material-slot-index -> json-material-data heuristics (spec §6)
+# ---------------------------------------------------------------------------
+
+def _find_skin_mat(skin_mats, slot_name):
+    for skin_mat in skin_mats:
+        if skin_mat.get("slot_name") == slot_name:
+            return skin_mat
+    return None
+
+
+def resolve_material_source(entry, index, skin_mats, npc_uses_skin):
+    # type: (Dict[str, Any], int, List[Dict], bool) -> Tuple[str, Dict[str, Any]]
+    """
+    Determines which json material data (and which "derived" shader type)
+    governs a given material-slot index on an imported mesh.
+
+    The json only ever fully describes material-slot 0 (the entry's own
+    materialInfo) and, for head/creature slots, an additional eyeMatInfo
+    block -- it does not say which mesh material-slot indices actually
+    exist, or what a 2nd slot on non-head/creature gear represents. This
+    heuristic chain is inherited from the original importer, since
+    Jedipedia exports don't include "materialSkinIndex" data that would
+    make this unambiguous.
+
+    Returns (derived, mat_info).
+    """
+    slot_name = entry["slotName"]
+    mat_info = entry["materialInfo"]
+    other_values = mat_info.get("otherValues", {})
+    derived = other_values.get("derived")
+    derived = "Creature" if derived == "HighQualityCharacter" else derived
+
+    if index == 1:
+        if slot_name in ("head", "creature"):
+            eye_mat_info = mat_info.get("eyeMatInfo", {})
+
+            # eyeMatInfo self-describes its own type via its own
+            # otherValues.derived -- confirmed against real data: a
+            # genuine Eye's eyeMatInfo.otherValues.derived is "Eye"
+            # (Tatooine/Balmorra heads), while a 2nd material slot that
+            # is actually a second Creature material (not an eye at
+            # all) has eyeMatInfo.otherValues.derived == 
+            # "HighQualityCharacter" (-> Creature) instead, e.g. Malgus.
+            # This replaces an earlier, less reliable heuristic (a
+            # malformed paletteMap path as the signal) that was written
+            # before any real "creature"-slot data was available to
+            # check it against, and which only applied to slot_name ==
+            # "creature", never "head" -- this direct read applies
+            # equally to both, and generalizes correctly to whatever
+            # eyeMatInfo actually says.
+            eye_other_values = eye_mat_info.get("otherValues", {})
+            eye_derived = eye_other_values.get("derived", "Eye")
+            eye_derived = "Creature" if eye_derived == "HighQualityCharacter" else eye_derived
+
+            return eye_derived, eye_mat_info
+
+        material_skin_index = other_values.get("materialSkinIndex")
+        if material_skin_index is not None:
+            if int(material_skin_index) == index:
+                derived = "SkinB"
         else:
-            try:
-                slot_name = entry["slotName"]
-                models = [path_format(filepath, f"/models/{slot_name}{model[model.rfind('/'):]}")
-                          for model in entry["models"]]
-                mat_info = entry["materialInfo"]
-                dds_dict = entry["materialInfo"]["ddsPaths"]
+            # Jedipedia doesn't currently emit materialSkinIndex at all,
+            # so this operator-toggle guess is the normal path in
+            # practice.
+            if npc_uses_skin:
+                derived = "SkinB"
 
-                # As paths.json lacks directionMap data, read it from the .mat file
-                # that was gathered in the relevant materials' subfolders and add it
-                # to the dds_dict when the materialInfo's derived is Creature or
-                # HairC.
-                if mat_info["otherValues"]["derived"] in ['Creature', 'HairC']:
-                    mat_path = entry["materialInfo"]["matPath"]
-                    if self.use_modernization:
-                        mat_path = path_format( filepath, f"/materials_modernization/{slot_name}/{os.path.basename(mat_path)}" )
-                    else:
-                        mat_path = path_format( filepath, f"/materials/{slot_name}/{os.path.basename(mat_path)}" )
-                        
-                    try:
-                        mat_file = open(mat_path)
-                    except FileNotFoundError:
-                        print(f".mat file {mat_path} couldn't be opened to read directionMap data")
-                    else:
-                        with mat_file:
-                            xml_tree = ET.parse(mat_file)
-                            xml_root = xml_tree.getroot()
-                            # (DirectionMap's PascalCase comes from the .mat file)
-                            DirectionMap = xml_root.find("./input/[semantic='DirectionMap']")
-                            if DirectionMap != None:
-                                texturemap_path = DirectionMap.find("value").text + ".dds"
-                                texturemap_path = texturemap_path.replace("\\", "/")
-                                if texturemap_path[0:1] != "/":
-                                    texturemap_path = f"/{texturemap_path}" 
-                                dds_dict['directionMap'] = texturemap_path
+    # Whenever the resolved derived is SkinB -- whether natively so on
+    # the slot's own primary materialInfo (e.g. "hand", which can BE
+    # skin at index 0, no override needed), or via the guess/
+    # materialSkinIndex path above at index 1 -- a matching skinMats
+    # entry for this slot_name, if one exists, is preferred over the
+    # slot's own mat_info. Confirmed bug fix: the original importer's
+    # "elif derived == 'SkinB':" branch always did this lookup
+    # regardless of why derived ended up being SkinB; an earlier
+    # revision of this rewrite only did it for the index-1 guess path,
+    # silently using a slot's own (sometimes placeholder/wrong) palette
+    # data whenever it was natively SkinB already.
+    if derived == "SkinB":
+        skin_mat = _find_skin_mat(skin_mats, slot_name)
+        if skin_mat is not None:
+            return "SkinB", skin_mat["mat_info"]
 
-                for key in mat_info["ddsPaths"]:
-                    tex = dds_dict[key][dds_dict[key].rfind('/'):]
-                    # if dds_dict[key] == "/.dds" or dds_dict[key] == ".dds":
-                    #     tex = "/black.dds"
-
-                    if self.use_modernization:
-                        mat_info["ddsPaths"][key] = \
-                            path_format(filepath,
-                                        f"/materials_modernization/{slot_name}"
-                                        f"{tex}")
-                    else:
-                        mat_info["ddsPaths"][key] = \
-                            path_format(filepath,
-                                        f"/materials/{slot_name}"
-                                        f"{tex}")
-
-                slot = {"slot_name": slot_name, "mat_info": mat_info, "models": models}
-
-                if any(name in slot["slot_name"] for name in {'head', 'creature'}):
-                    if "eyeMatInfo" in entry["materialInfo"]:
-                        eye_mat_info = entry["materialInfo"]["eyeMatInfo"]
-                        dds_dict = eye_mat_info["ddsPaths"]
-
-                        for key in eye_mat_info["ddsPaths"]:
-                            if self.use_modernization:
-                                eye_mat_info["ddsPaths"][key] = \
-                                    path_format(filepath,
-                                                f"/materials_modernization/eye{dds_dict[key][dds_dict[key].rfind('/'):]}")
-                            else:
-                                eye_mat_info["ddsPaths"][key] = \
-                                    path_format(filepath,
-                                                f"/materials/eye{dds_dict[key][dds_dict[key].rfind('/'):]}")
-
-                        _eye_mat_info = {"slot_name": "eye", "mat_info": eye_mat_info}
-
-                parsed_objects.append(slot)
-            except Exception:
-                print("AN ERROR HAS OCCURED.")  # TODO: Improve this error handling! - Crunch Note, Fix for Single Material Creatures
-    #print(parsed_objects)
-    return parsed_objects, skin_materials
+    return derived, mat_info
 
 
-def build(operator, context, slots, skin_mats,
-          job_results_rich = False):
-    # type: (Operator, Context, None, None, False) -> bool
-    '''
-    Imports .gr2 object files and assigns them
-    materials using this add-on's SWTOR shaders
-    '''
+# ---------------------------------------------------------------------------
+# Variant import (spec §5, §10's import_variant())
+# ---------------------------------------------------------------------------
+
+def _job_results_key(filepath):
+    """
+    Mirrors import_gr2.py's own key-normalization for
+    job_results['files_objs_names'], so lookups against it line up. See
+    that module's load() for the authoritative version of this logic.
+    """
+    normalized = filepath.replace("\\", "/")
+    if "resources" in normalized:
+        return normalized.partition("resources/")[2]
+    return normalized
 
 
+def import_variant(operator, context, resources_root, entry, skin_mats):
+    # type: (Any, Any, str, Dict[str, Any], List[Dict]) -> List[Any]
+    """
+    Imports every model listed in a single slot entry (spec §5's "one
+    variant") and assigns materials to every resulting Blender object --
+    a single .gr2 can produce more than one object (multi-mesh files),
+    and all of them get materials now, not just the first one (confirmed
+    fix; the original importer only handled the first).
 
-    for slot in slots:
-        print()
-        print()
-        print(f"{slot['slot_name'].upper()} OBJECTS:")
-        print("-" * 80)
-        for model in slot["models"]:
-            # Import gr2. The .gr2 import module will
-            # read parameters from this module's class'
-            # properties via the operator param (it
-            # carries the class' self.)
-            ImportGR2_load(operator, context, model)
-            
-            name = path_split(model)[:-4]
+    Returns the list of imported Objects. Empty if entry["models"] is
+    empty -- a valid "none" variant (e.g. a bald/clean-shaven option),
+    not an error.
+    """
+    imported_objects = []
+
+    for model_path in entry.get("models", []):
+        resolved_path = resolve_resource_path(resources_root, model_path)
+
+        # Rich results are required so we can look up exactly which
+        # object(s) this specific import call produced -- a plain
+        # bpy.data.objects[name] guess breaks whenever two variants
+        # share the same source .gr2 filename (confirmed real case:
+        # multiple head sculpts reusing one mesh with different
+        # materials).
+        operator.job_results_rich = True
+
+        ImportGR2_load(operator, context, resolved_path)
+
+        object_names = job_results.get("files_objs_names", {}).get(
+            _job_results_key(resolved_path), []
+        )
+
+        for object_name in object_names:
+            ob = bpy.data.objects[object_name]
+            imported_objects.append(ob)
+
+            for index in range(len(ob.material_slots)):
+                derived, mat_info = resolve_material_source(
+                    entry, index, skin_mats, operator.npc_uses_skin,
+                )
+                mat_path = mat_info.get("matPath")
+                if not mat_path:
+                    continue
+
+                mat_name = Path(mat_path).stem
+                material = get_or_create_material(
+                    resources_root, mat_name, derived, mat_info,
+                )
+                ob.material_slots[index].material = material
+
+    return imported_objects
 
 
-            # Set material for model
-            ob = bpy.data.objects[name]
+# ---------------------------------------------------------------------------
+# Skeleton import + binding (spec §8)
+# ---------------------------------------------------------------------------
 
-            for i, mat_slot in enumerate(ob.material_slots):
-                derived = slot["mat_info"]["otherValues"]["derived"]
-                derived = "Creature" if derived == "HighQualityCharacter" else derived
-                derived = ("Eye" if any(x in slot["slot_name"] for x in {"head", "creature"})
-                           and i == 1 else derived)
-                
-                # HORRIBLE HACK FOR CREATURE IMPORTS WHERE THE SECOND MATERIAL
-                # ISN'T REALLY AN EYE BUT A HIGHQUALITYCHARACTER/CREATURE ONE:
-                # We are using the presence of a malformed paletteMap "/.dds"
-                # texturemap filename (necessary in Eye shaders but not in
-                # Creature ones) as a criteria to change the Derived to Creature
-                # (we used to manually correct those entries in the .json data.
-                # Now we must NOT correct them, as their presence helps us here).
-                
-                creature_2nd_mat_is_creature_instead_of_eye = False
-                if i == 1:
-                    if slot["slot_name"] == 'creature' and (
-                        slot['mat_info']['eyeMatInfo']['ddsPaths']['paletteMap'].endswith("\\.dds") or
-                        slot['mat_info']['eyeMatInfo']['ddsPaths']['paletteMap'].endswith("/.dds")
-                        ):
-                        derived = "Creature"
-                        creature_2nd_mat_is_creature_instead_of_eye = True
+def _parse_dyc_skeleton(dyc_path):
+    # type: (str) -> Optional[str]
+    """
+    Extracts the "Skeleton=..." filename from a .dyc file's [SETTINGS]
+    section (e.g. "Skeleton=bmnnew_skeleton.gr2" -> "bmnnew_skeleton.gr2").
 
-                
-                
-                new_mat = None
-                mat_idx = '{:0>2}'.format(i + 1) if i + 1 < 10 else str(i + 1)
-                slot_name = slot["slot_name"]
+    .dyc files are INI-like, but this is a hand-rolled line scan rather
+    than configparser: other sections (e.g. [MASKS]) contain repeated
+    keys ("mask=...") and unlabeled indented sub-entries that aren't
+    valid strict INI and would trip configparser's stricter parsing long
+    before ever reaching [SETTINGS].
 
+    Returns the skeleton filename, or None if not found.
+    """
+    current_section = None
+
+    with open(dyc_path, encoding="utf-8", errors="replace") as file:
+        for line in file:
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            if stripped.startswith("[") and stripped.endswith("]"):
+                current_section = stripped[1:-1].upper()
+                continue
+
+            if current_section == "SETTINGS" and "=" in stripped:
+                key, _, value = stripped.partition("=")
+                if key.strip().lower() == "skeleton":
+                    return value.strip()
+
+    return None
+
+
+def import_skeleton(operator, context, resources_root, meta):
+    # type: (Any, Any, str, Dict[str, Any]) -> Optional[Any]
+    """
+    Imports the skeleton for this NPC, resolved via meta["BodyType"]
+    rather than a direct path in the json.
+
+    This moved server-side (Jedipedia) -> local resolution: Jedipedia
+    can't reliably determine the actual skeleton file server-side, but
+    it's straightforward locally, in two steps:
+
+        1. "/art/dynamic/spec/<BodyType>.dyc" is read directly (e.g.
+           "bmn.dyc" for BodyType "bmn"). This is an INI-like file whose
+           [SETTINGS] section has a "Skeleton=<filename>.gr2" line
+           giving the actual skeleton filename (e.g.
+           "bmnnew_skeleton.gr2") -- confirmed this filename does NOT
+           always match "<BodyType>_skeleton.gr2" or similar, hence
+           needing to actually read it rather than guessing a pattern.
+        2. That filename lives in the same /art/dynamic/spec/ directory
+           as the .dyc file itself.
+
+    Tolerant by design: a missing/empty BodyType, a missing .dyc file, a
+    .dyc with no [SETTINGS] Skeleton= line, or a skeleton path that
+    doesn't resolve to an existing file, is not an error -- it just
+    means no skeleton gets imported (spec §8: "should be able to handle
+    skeletons but not require them").
+
+    Returns the imported armature Object, or None.
+    """
+    body_type = meta.get("BodyType")
+    if not body_type:
+        return None
+
+    dyc_path = resolve_resource_path(resources_root, "/art/dynamic/spec/%s.dyc" % body_type)
+    if not dyc_path or not Path(dyc_path).exists():
+        operator.report(
+            {'WARNING'},
+            "Skeleton definition file not found, skipping: %s" % (dyc_path or body_type,),
+        )
+        return None
+
+    skeleton_filename = _parse_dyc_skeleton(dyc_path)
+    if not skeleton_filename:
+        operator.report(
+            {'WARNING'},
+            "No [SETTINGS] Skeleton= entry found in %s, skipping." % (dyc_path,),
+        )
+        return None
+
+    resolved_path = resolve_resource_path(resources_root, "/art/dynamic/spec/%s" % skeleton_filename)
+    if not resolved_path or not Path(resolved_path).exists():
+        operator.report(
+            {'WARNING'},
+            "Skeleton file not found, skipping: %s" % (resolved_path or skeleton_filename,),
+        )
+        return None
+
+    operator.job_results_rich = True
+    ImportGR2_load(operator, context, resolved_path)
+
+    object_names = job_results.get("files_objs_names", {}).get(
+        _job_results_key(resolved_path), []
+    )
+    if not object_names:
+        return None
+
+    # A skeleton .gr2 is expected to produce a single armature object;
+    # if it somehow produces more, the first is treated as the main one
+    # (same "first object is main" assumption used elsewhere in this
+    # add-on for multi-object imports).
+    skeleton_ob = bpy.data.objects[object_names[0]]
+    skeleton_ob.show_in_front = True
+
+    return skeleton_ob
+
+
+def bind_objects_to_armature(objects, armature, single_armature_only=True):
+    # type: (List[Any], Any, bool) -> None
+    """
+    Binds a set of objects to an armature via Armature modifiers, ported
+    unchanged from the original ZG_Tools assembler.
+
+    :param objects: list of Objects to bind
+    :param armature: the armature Object
+    :param single_armature_only: skip objects that already have an
+        Armature modifier, rather than adding a second one
+    """
+    for obj in objects:
+        if obj.type != 'MESH':
+            continue
+
+        if single_armature_only and any(mod.type == 'ARMATURE' for mod in obj.modifiers):
+            continue
+
+        mod = obj.modifiers.new(name="Armature", type='ARMATURE')
+        mod.object = armature
+
+        # Create a parent relationship. Don't use a parent_type of
+        # 'ARMATURE' -- the modifier above is already doing that job.
+        obj.parent = armature
+        obj.matrix_parent_inverse = armature.matrix_world.inverted()
+        
+        # Enable Preserve Volume on Armature Modifier by Default
+        obj.modifiers["Armature"].use_deform_preserve_volume = True
+
+        # Automatic weight assignment needs the operator context
+        # (bpy.ops.object.parent_set(type='ARMATURE_AUTO')) and isn't
+        # done here; weights are assumed to be assigned manually or via
+        # another process.
+
+
+# ---------------------------------------------------------------------------
+# Collection assembly (spec §7)
+# ---------------------------------------------------------------------------
+
+def assemble_collections(context, npc_name, slot_objects, skeleton_ob=None, character_name_suffix=None):
+    # type: (Any, str, Dict[str, List[Any]], Optional[Any], Optional[str]) -> Any
+    """
+    Builds the NPC's Collection hierarchy:
+
+        <NPC Collection>              # named from npc_name
+         |-- <SlotName>                # one per slot that produced objects
+         |    |-- variant object 1     # (capitalized -- "head" -> "Head")
+         |    `-- variant object 2
+         |-- ...
+         |-- <creature slot's object(s)>  # directly in the NPC Collection,
+         |                                # no "Creature" sub-collection --
+         |                                # it's effectively the whole NPC
+         `-- <skeleton object>        # directly in the NPC Collection, if any
+
+    slot_objects: dict mapping slotName -> list of imported Objects for
+    that slot. A slot with no objects (an all-empty-models variant, e.g.
+    a bald/clean-shaven "none" option -- spec §5) is simply skipped, no
+    empty Collection is created for it.
+
+    character_name_suffix: if given, appended to every per-slot
+    Collection's name as " - <suffix>" (e.g. "Boot" -> "Boot - Republic
+    Officer"). Only meant to be passed when the "Append Character Name
+    to Collections" import option is on AND the json's meta.charName is
+    actually present -- callers decide that, this function just appends
+    whatever string it's given (or nothing, if None). Not applied to the
+    NPC root Collection itself, since that's already named from npc_name.
+
+    Every Collection is created fresh via bpy.data.collections.new()
+    rather than looked up/reused by name -- seebpy.data.collections is a
+    global namespace, not scoped by nesting; reusing an existing
+    same-named Collection across two different NPC imports in the same
+    file would merge their objects together, which is never wanted here.
+    Letting Blender auto-suffix duplicate names (".001", ".002", ...) is
+    the safe default.
+
+    Returns the NPC root Collection.
+    """
+    npc_collection = bpy.data.collections.new(npc_name)
+    context.scene.collection.children.link(npc_collection)
+
+    for slot_name, objects in slot_objects.items():
+        if not objects:
+            continue
+
+        # The "creature" slot is effectively the whole NPC on
+        # creature-type imports (e.g. Malgus) -- it doesn't get its own
+        # sub-collection, its objects go straight into the NPC root,
+        # same as the skeleton.
+        target_collection = npc_collection
+        if slot_name != "creature":
+            collection_name = slot_name.capitalize()
+            if character_name_suffix:
+                collection_name = "%s - %s" % (collection_name, character_name_suffix)
+            target_collection = bpy.data.collections.new(collection_name)
+            npc_collection.children.link(target_collection)
+
+        for ob in objects:
+            target_collection.objects.link(ob)
+            # ImportGR2_load() links newly created objects into whatever
+            # collection is active in the view layer at import time --
+            # remove that link now that the object has its proper home.
+            for existing_collection in list(ob.users_collection):
+                if existing_collection is not target_collection:
+                    existing_collection.objects.unlink(ob)
+
+    if skeleton_ob is not None:
+        npc_collection.objects.link(skeleton_ob)
+        for existing_collection in list(skeleton_ob.users_collection):
+            if existing_collection is not npc_collection:
+                existing_collection.objects.unlink(skeleton_ob)
+
+    return npc_collection
+
+
+# ---------------------------------------------------------------------------
+# Twi'lek eyes UV fix + eye separation (spec §9, ported from ZG_Tools)
+# ---------------------------------------------------------------------------
+
+def translate_uv_coordinates(mesh_object, material_slot=None, uv_offset=(0, 0)):
+    """
+    Offsets an object's polys' UVs, either all of them or only those
+    associated with a specific material slot. Motivated by Twi'lek
+    heads' off-image-bounds eye UVs producing black bakes.
+
+    Ported unchanged from the original ZG_Tools assembler.
+    """
+    if mesh_object.type != 'MESH':
+        return
+
+    mesh = mesh_object.data
+    if not mesh.uv_layers.active:
+        return
+
+    uv_layer = mesh.uv_layers.active.data
+
+    for face in mesh.polygons:
+        if material_slot is None or face.material_index == material_slot:
+            for loop_index in face.loop_indices:
+                uv = uv_layer[loop_index].uv
+                if uv.y <= 1:
+                    return
+                uv.x += uv_offset[0]
+                uv.y += uv_offset[1]
+
+
+def duplicate_obj(obj_or_obj_name):
+    """
+    Creates a full duplicate of an object (mesh data, transforms,
+    modifiers, constraints, animation data, custom properties), linked
+    into the same Collection(s) as the original.
+
+    Ported unchanged from the original ZG_Tools assembler.
+    """
+    if isinstance(obj_or_obj_name, str):
+        obj = bpy.data.objects[obj_or_obj_name]
+    else:
+        obj = obj_or_obj_name
+
+    new_data = obj.data.copy()
+    new_obj = bpy.data.objects.new(obj.name + ".copy", new_data)
+
+    for col in obj.users_collection:
+        col.objects.link(new_obj)
+
+    new_obj.location = obj.location.copy()
+    new_obj.rotation_euler = obj.rotation_euler.copy()
+    new_obj.rotation_quaternion = obj.rotation_quaternion.copy()
+    new_obj.scale = obj.scale.copy()
+    new_obj.data = new_data
+
+    for prop in obj.keys():
+        if prop != "_RNA_UI":
+            new_obj[prop] = obj[prop]
+
+    for mod in obj.modifiers:
+        new_mod = new_obj.modifiers.new(name=mod.name, type=mod.type)
+        for attr in dir(mod):
+            if not attr.startswith("_") and attr not in {"type", "name", "rna_type"}:
                 try:
-                    if not creature_2nd_mat_is_creature_instead_of_eye:
-                        new_mat = bpy.data.materials[f"{mat_idx} {slot_name}{derived}"]
-                    else:
-                        new_mat = bpy.data.materials[f"{mat_idx} {slot_name}Creature"]
-                except KeyError:
-                    # This part failed for TORCommunity.com's creature NPC exports because
-                    # the last server restore didn't have the correction to include
-                    # their materialSkinIndex data:
-                    #
-                    # So, in its absence, we use the npc_uses_skin parameter (which
-                    # defaults to True because it's the most typical case)
-                    
-                    
-                    if "materialSkinIndex" in slot["mat_info"]["otherValues"]:
-                        if int(slot["mat_info"]["otherValues"]["materialSkinIndex"]) == i:
-                            derived = "SkinB"
-                    else:
-                        if not creature_2nd_mat_is_creature_instead_of_eye:
-                            if i == 1 and (slot_name != "head" and slot_name != 'creature'):
-                                if operator.npc_uses_skin:
-                                    derived = "SkinB"
+                    setattr(new_mod, attr, getattr(mod, attr))
+                except AttributeError:
+                    pass
+
+        if mod.type == 'ARMATURE':
+            new_mod.object = mod.object
+
+    if obj.animation_data:
+        new_obj.animation_data_create()
+        new_obj.animation_data.action = obj.animation_data.action
+        new_obj.animation_data.action = obj.animation_data.action.copy()
+
+    for constr in obj.constraints:
+        new_constr = new_obj.constraints.new(type=constr.type)
+        for attr in dir(constr):
+            if not attr.startswith("_") and attr not in {"type", "name", "rna_type"}:
+                try:
+                    setattr(new_constr, attr, getattr(constr, attr))
+                except AttributeError:
+                    pass
+
+    return new_obj
 
 
-                    new_mat = bpy.data.materials.new(f"{mat_idx} {slot_name}{derived}")
-                    new_mat.use_nodes = True
-                    
-                    # Delete default Principled BSDF shader node
-                    for nd in new_mat.node_tree.nodes:
-                        if nd.type == "BSDF_PRINCIPLED":
-                            new_mat.node_tree.nodes.remove(nd)
-                            break
+def separate_obj_by_specific_materials(obj_or_obj_name, material_names, separate=True):
+    """
+    Separates an object's polys associated with the given material(s)
+    into a new object per material. By default, also deletes those
+    polys and material slots from the original object.
 
-                    node = new_mat.node_tree.nodes.new(type="ShaderNodeHeroEngine")
-                    node.location = (0.0, 300.0)
+    :param material_names: a material name, or a list of material names.
 
-                    new_mat.node_tree.links.new(
-                        node.outputs["Shader"],
-                        new_mat.node_tree.nodes["Material Output"].inputs["Surface"],
-                    )
+    Ported from the original ZG_Tools assembler, with one clarity fix:
+    the original accepted a single material name string and tested
+    membership via Python's substring-`in` on that string, despite its
+    own docstring describing it as "a list of materials names" --
+    happened to work for how it was actually called (the exact same
+    string on both sides of `in`), but is genuinely a list-membership
+    check now, matching the docstring.
+    """
+    if isinstance(material_names, str):
+        material_names = [material_names]
 
-                    imgs = bpy.data.images
+    if isinstance(obj_or_obj_name, str):
+        original_obj = bpy.data.objects[obj_or_obj_name]
+    else:
+        original_obj = obj_or_obj_name
 
-                    if derived == 'Creature' and creature_2nd_mat_is_creature_instead_of_eye is False:
-                        
-                        node.derived = 'CREATURE'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                            new_mat.show_transparent_back = False
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
-                            new_mat.use_transparency_overlap = False
+    original_mesh = original_obj.data
+    new_objs = []
 
-                        mat_info = slot["mat_info"]
-                        other_values = mat_info['otherValues']
+    mat_indices = [
+        i for i, mat in enumerate(original_mesh.materials) if mat.name in material_names
+    ]
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+    if separate:
+        for mat_index in mat_indices:
+            new_obj = original_obj.copy()
+            new_obj.data = original_obj.data.copy()
+            bpy.context.collection.objects.link(new_obj)
+            new_obj.name = "%s_%s" % (original_obj.name, original_mesh.materials[mat_index].name)
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+            bm = bmesh.new()
+            bm.from_mesh(new_obj.data)
+            faces_to_delete = [f for f in bm.faces if f.material_index != mat_index]
+            bmesh.ops.delete(bm, geom=faces_to_delete, context='FACES')
+            bm.to_mesh(new_obj.data)
+            bm.free()
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+            new_objs.append(new_obj)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info["ddsPaths"]["paletteMaskMap"])
+    bm = bmesh.new()
+    bm.from_mesh(original_mesh)
+    faces_to_delete = [f for f in bm.faces if f.material_index in mat_indices]
+    bmesh.ops.delete(bm, geom=faces_to_delete, context='FACES')
+    bm.to_mesh(original_mesh)
+    bm.free()
 
-                        if "directionMap" in mat_info["ddsPaths"]:
-                            img = path_split(mat_info["ddsPaths"]["directionMap"])
-                            if img in imgs:
-                                node.directionMap = imgs[img]
-                            else:
-                                node.directionMap = imgs.load(mat_info["ddsPaths"]["directionMap"])
+    for i, slot in enumerate(original_obj.material_slots[:]):
+        if slot.material and slot.material.name in material_names:
+            original_obj.data.materials.pop(index=i)
 
-                        # try:
-                        #     node.directionMap = imgs[path_split(mat_info["ddsPaths"]['directionMap'])]
-                        # except KeyError:
-                        #     node.directionMap = imgs.load(mat_info["ddsPaths"]['directionMap'])
-
-                        node.flesh_brightness = float(other_values['fleshBrightness'])
-                        node.flush_tone = [
-                            float(other_values['flush'][0]),
-                            float(other_values['flush'][1]),
-                            float(other_values['flush'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'Creature' and creature_2nd_mat_is_creature_instead_of_eye is True:
-                        # It feeds a 'Creature' shader but the data it grabs comes from the parsed
-                        # paths.json file's 'eye' shader data. I rather don't try to generalize that
-                        # into a single chunk of code.
-                        
-                        node.derived = 'CREATURE'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                            new_mat.show_transparent_back = False
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
-                            new_mat.use_transparency_overlap = False
-
-                        mat_info = slot["mat_info"]
-                        other_values = mat_info['eyeMatInfo']['otherValues']
-
-                        img = path_split(mat_info['eyeMatInfo']["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info['eyeMatInfo']["ddsPaths"]["diffuseMap"])
-
-                        img = path_split(mat_info['eyeMatInfo']["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info['eyeMatInfo']["ddsPaths"]["rotationMap"])
-
-                        img = path_split(mat_info['eyeMatInfo']["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
-
-                        img = path_split(mat_info['eyeMatInfo']["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info['eyeMatInfo']["ddsPaths"]["paletteMaskMap"])
-
-                        if "directionMap" in mat_info['eyeMatInfo']["ddsPaths"]:
-                            img = path_split(mat_info['eyeMatInfo']["ddsPaths"]["directionMap"])
-                            if img in imgs:
-                                node.directionMap = imgs[img]
-                            else:
-                                node.directionMap = imgs.load(mat_info['eyeMatInfo']["ddsPaths"]["directionMap"])
-
-                        # try:
-                        #     node.directionMap = imgs[path_split(mat_info['eyeMatInfo']["ddsPaths"]['directionMap'])]
-                        # except KeyError:
-                        #     node.directionMap = imgs.load(mat_info['eyeMatInfo']["ddsPaths"]['directionMap'])
-
-                        node.flesh_brightness = float(other_values['fleshBrightness'])
-                        node.flush_tone = [
-                            float(other_values['flush'][0]),
-                            float(other_values['flush'][1]),
-                            float(other_values['flush'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'Eye':
-                        
-                        node.derived = 'EYE'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        new_mat.show_transparent_back = False
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
+    return new_objs
 
 
-                        mat_info = _eye_mat_info["mat_info"]
-                        other_values = mat_info['otherValues']
+def delete_polygons_on_side(obj_or_obj_name, side='LEFT'):
+    """
+    Deletes every polygon on the given side of local X == 0.
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+    Ported unchanged from the original ZG_Tools assembler.
+    """
+    if isinstance(obj_or_obj_name, str):
+        obj = bpy.data.objects[obj_or_obj_name]
+    else:
+        obj = obj_or_obj_name
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+    if obj.mode != 'OBJECT':
+        bpy.ops.object.mode_set(mode='OBJECT')
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+    mesh = obj.data
+    bm = bmesh.new()
+    bm.from_mesh(mesh)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMap"])
-                        if img in imgs:
-                            node.paletteMap = imgs[img]
-                        else:
-                            node.paletteMap = imgs.load(mat_info["ddsPaths"]["paletteMap"])
+    faces_to_delete = []
+    for face in bm.faces:
+        center = face.calc_center_median()
+        if side == 'LEFT' and center.x < 0:
+            faces_to_delete.append(face)
+        elif side == 'RIGHT' and center.x >= 0:
+            faces_to_delete.append(face)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info["ddsPaths"]["paletteMaskMap"])
+    bmesh.ops.delete(bm, geom=faces_to_delete, context='FACES')
+    bm.to_mesh(mesh)
+    bm.free()
 
-                        node.palette1_hue = float(other_values['palette1'][0])
-                        node.palette1_saturation = float(other_values['palette1'][1])
-                        node.palette1_brightness = float(other_values['palette1'][2])
-                        node.palette1_contrast = float(other_values['palette1'][3])
-                        node.palette1_specular = [
-                            float(other_values['palette1Specular'][0]),
-                            float(other_values['palette1Specular'][1]),
-                            float(other_values['palette1Specular'][2]),
-                            1.0,
-                        ]
-                        node.palette1_metallic_specular = [
-                            float(other_values['palette1MetallicSpecular'][0]),
-                            float(other_values['palette1MetallicSpecular'][1]),
-                            float(other_values['palette1MetallicSpecular'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'Garment' or derived == 'GarmentScrolling':
-                        
-                        node.derived = 'GARMENT'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        new_mat.show_transparent_back = False
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
 
-                        mat_info = slot["mat_info"]
-                        other_values = mat_info['otherValues']
+def get_highest_and_lowest_vertices(obj_or_obj_name):
+    """
+    Returns (highest_vertex, lowest_vertex) world-space coordinates by Z.
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+    Ported unchanged from the original ZG_Tools assembler.
+    """
+    if isinstance(obj_or_obj_name, str):
+        obj = bpy.data.objects[obj_or_obj_name]
+    else:
+        obj = obj_or_obj_name
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+    bpy.ops.object.mode_set(mode='OBJECT')
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+    bm = bmesh.new()
+    bm.from_mesh(obj.data)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMap"])
-                        if img in imgs:
-                            node.paletteMap = imgs[img]
-                        else:
-                            node.paletteMap = imgs.load(mat_info["ddsPaths"]["paletteMap"])
+    global_matrix = obj.matrix_world
+    highest_vertex = None
+    lowest_vertex = None
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info["ddsPaths"]["paletteMaskMap"])
+    for v in bm.verts:
+        global_coord = global_matrix @ v.co
+        if highest_vertex is None or global_coord.z > highest_vertex.z:
+            highest_vertex = global_coord
+        if lowest_vertex is None or global_coord.z < lowest_vertex.z:
+            lowest_vertex = global_coord
 
-                        node.palette1_hue = float(other_values['palette1'][0])
-                        node.palette1_saturation = float(other_values['palette1'][1])
-                        node.palette1_brightness = float(other_values['palette1'][2])
-                        node.palette1_contrast = float(other_values['palette1'][3])
-                        node.palette1_specular = [
-                            float(other_values['palette1Specular'][0]),
-                            float(other_values['palette1Specular'][1]),
-                            float(other_values['palette1Specular'][2]),
-                            1.0,
-                        ]
-                        node.palette1_metallic_specular = [
-                            float(other_values['palette1MetallicSpecular'][0]),
-                            float(other_values['palette1MetallicSpecular'][1]),
-                            float(other_values['palette1MetallicSpecular'][2]),
-                            1.0,
-                        ]
+    bm.free()
 
-                        node.palette2_hue = float(other_values['palette2'][0])
-                        node.palette2_saturation = float(other_values['palette2'][1])
-                        node.palette2_brightness = float(other_values['palette2'][2])
-                        node.palette2_contrast = float(other_values['palette2'][3])
-                        node.palette2_specular = [
-                            float(other_values['palette2Specular'][0]),
-                            float(other_values['palette2Specular'][1]),
-                            float(other_values['palette2Specular'][2]),
-                            1.0,
-                        ]
-                        node.palette2_metallic_specular = [
-                            float(other_values['palette2MetallicSpecular'][0]),
-                            float(other_values['palette2MetallicSpecular'][1]),
-                            float(other_values['palette2MetallicSpecular'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'HairC':
-                        
-                        node.derived = 'HAIRC'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        new_mat.show_transparent_back = False
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
+    return highest_vertex, lowest_vertex
 
-                        mat_info = slot["mat_info"]
-                        other_values = mat_info['otherValues']
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+def set_obj_origin(obj_or_obj_name, new_origin):
+    """
+    Moves an object's origin to new_origin (world space), preserving its
+    visual position by compensating the mesh data's transform.
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+    Ported unchanged from the original ZG_Tools assembler.
+    """
+    if isinstance(obj_or_obj_name, str):
+        obj = bpy.data.objects[obj_or_obj_name]
+    else:
+        obj = obj_or_obj_name
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+    new_origin = Vector(new_origin)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMap"])
-                        if img in imgs:
-                            node.paletteMap = imgs[img]
-                        else:
-                            node.paletteMap = imgs.load(mat_info["ddsPaths"]["paletteMap"])
+    obj_matrix = obj.matrix_world
+    current_origin_world = obj_matrix @ Vector((0, 0, 0))
+    delta_world = new_origin - current_origin_world
+    delta_object_space = obj_matrix.inverted() @ delta_world
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info["ddsPaths"]["paletteMaskMap"])
+    obj.location += delta_world
+    obj.data.transform(Matrix.Translation(-delta_object_space))
+    obj.data.update()
 
-                        img = path_split(mat_info["ddsPaths"]["directionMap"])
-                        if img in imgs:
-                            node.directionMap = imgs[img]
-                        else:
-                            node.directionMap = imgs.load(mat_info["ddsPaths"]["directionMap"])
 
-                        # img = path_split(mat_info["ddsPaths"]["directionMap"])
-                        # if img in imgs:
-                        #     node.directionMap = imgs[img]
-                        # else:
-                        #     node.directionMap = imgs.load(mat_info["ddsPaths"]["directionMap"])
+def apply_twilek_eyes_uv_fix(slot_objects):
+    # type: (Dict[str, List[Any]]) -> None
+    """
+    Applies translate_uv_coordinates() to every Twi'lek head object's
+    Eye material slot (index 1), in place.
 
-                        node.palette1_hue = float(other_values['palette1'][0])
-                        node.palette1_saturation = float(other_values['palette1'][1])
-                        node.palette1_brightness = float(other_values['palette1'][2])
-                        node.palette1_contrast = float(other_values['palette1'][3])
-                        node.palette1_specular = [
-                            float(other_values['palette1Specular'][0]),
-                            float(other_values['palette1Specular'][1]),
-                            float(other_values['palette1Specular'][2]),
-                            1.0,
-                        ]
-                        node.palette1_metallic_specular = [
-                            float(other_values['palette1MetallicSpecular'][0]),
-                            float(other_values['palette1MetallicSpecular'][1]),
-                            float(other_values['palette1MetallicSpecular'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'SkinB':
-                        
-                        node.derived = 'SKINB'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        new_mat.show_transparent_back = False
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
+    Deviates from the original in one way: the original stopped after
+    the first Twi'lek head object found across the whole NPC. Now that
+    a single NPC can have multiple head variants (spec §5), this applies
+    to every matching head variant instead.
+    """
+    for head_ob in slot_objects.get("head", []):
+        if "head_twilek" in head_ob.name:
+            translate_uv_coordinates(head_ob, 1, (0, -2))
 
-                        skin_mat = next(
-                            (mat for mat in skin_mats["mats"] if mat["slot_name"] == slot["slot_name"]),
-                            None,
-                        )
-                        mat_info = skin_mat["mat_info"] if skin_mat is not None else slot["mat_info"]
-                        other_values = mat_info['otherValues']
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+def separate_head_eyes(slot_objects, separate_each_eye):
+    # type: (Dict[str, List[Any]], bool) -> None
+    """
+    For every head object with an Eye material in its 2nd material slot,
+    splits the eyes out into their own object (or two objects, one per
+    eye, if separate_each_eye is set) and appends them into
+    slot_objects["head"] so they end up correctly placed by
+    assemble_collections().
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+    Iterates over a snapshot of slot_objects["head"] rather than the
+    live list, since new eye objects get appended into that same list
+    as this runs.
+    """
+    for head_ob in list(slot_objects.get("head", [])):
+        if len(head_ob.material_slots) <= 1:
+            continue
+        if "eye" not in head_ob.material_slots[1].name.lower():
+            continue
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+        eyes_ob = duplicate_obj(head_ob)
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMap"])
-                        if img in imgs:
-                            node.paletteMap = imgs[img]
-                        else:
-                            node.paletteMap = imgs.load(mat_info["ddsPaths"]["paletteMap"])
+        # Delete the eyes' polys/material from the head object, and the
+        # head's polys/material from the eyes object (the duplicate).
+        separate_obj_by_specific_materials(
+            head_ob, head_ob.material_slots[1].name, separate=False,
+        )
+        separate_obj_by_specific_materials(
+            eyes_ob, eyes_ob.material_slots[0].name, separate=False,
+        )
 
-                        img = path_split(mat_info["ddsPaths"]["paletteMaskMap"])
-                        if img in imgs:
-                            node.paletteMaskMap = imgs[img]
-                        else:
-                            node.paletteMaskMap = imgs.load(mat_info["ddsPaths"]["paletteMaskMap"])
+        if not separate_each_eye:
+            eyes_ob.name = "%s.eyes" % head_ob.name
+            slot_objects.setdefault("head", []).append(eyes_ob)
+            continue
 
-                        if "ageMap" in mat_info["ddsPaths"]:
-                            img = path_split(mat_info["ddsPaths"]["ageMap"])
-                            if img in imgs:
-                                node.ageMap = imgs[img]
-                            else:
-                                node.ageMap = imgs.load(mat_info["ddsPaths"]["ageMap"])
+        eyes_ob_right = eyes_ob
+        eyes_ob_left = duplicate_obj(eyes_ob)
 
-                        if "complexionMap" in mat_info["ddsPaths"]:
-                            img = path_split(mat_info["ddsPaths"]["complexionMap"])
-                            if img in imgs:
-                                node.complexionMap = imgs[img]
-                            else:
-                                node.complexionMap = imgs.load(mat_info["ddsPaths"]["complexionMap"])
+        delete_polygons_on_side(eyes_ob_right, side='LEFT')
+        highest_vertex, lowest_vertex = get_highest_and_lowest_vertices(eyes_ob_right)
+        set_obj_origin(
+            eyes_ob_right,
+            (highest_vertex.x, highest_vertex.y, (highest_vertex.z + lowest_vertex.z) / 2),
+        )
+        eyes_ob_right.name = "%s.eyes.right" % head_ob.name
+        slot_objects.setdefault("head", []).append(eyes_ob_right)
 
-                        if "facepaintMap" in mat_info["ddsPaths"]:
-                            img = path_split(mat_info["ddsPaths"]["facepaintMap"])
-                            if img in imgs:
-                                node.facepaintMap = imgs[img]
-                            else:
-                                node.facepaintMap = imgs.load(mat_info["ddsPaths"]["facepaintMap"])
+        delete_polygons_on_side(eyes_ob_left, side='RIGHT')
+        highest_vertex, lowest_vertex = get_highest_and_lowest_vertices(eyes_ob_left)
+        set_obj_origin(
+            eyes_ob_left,
+            (highest_vertex.x, highest_vertex.y, (highest_vertex.z + lowest_vertex.z) / 2),
+        )
+        eyes_ob_left.name = "%s.eyes.left" % head_ob.name
+        slot_objects.setdefault("head", []).append(eyes_ob_left)
 
-                        node.palette1_hue = float(other_values['palette1'][0])
-                        node.palette1_saturation = float(other_values['palette1'][1])
-                        node.palette1_brightness = float(other_values['palette1'][2])
-                        node.palette1_contrast = float(other_values['palette1'][3])
-                        node.palette1_specular = [
-                            float(other_values['palette1Specular'][0]),
-                            float(other_values['palette1Specular'][1]),
-                            float(other_values['palette1Specular'][2]),
-                            1.0,
-                        ]
-                        node.palette1_metallic_specular = [
-                            float(other_values['palette1MetallicSpecular'][0]),
-                            float(other_values['palette1MetallicSpecular'][1]),
-                            float(other_values['palette1MetallicSpecular'][2]),
-                            1.0,
-                        ]
 
-                        node.flesh_brightness = float(other_values['fleshBrightness'])
-                        node.flush_tone = [
-                            float(other_values['flush'][0]),
-                            float(other_values['flush'][1]),
-                            float(other_values['flush'][2]),
-                            1.0,
-                        ]
-                        
-                    elif derived == 'Uber':
-                        
-                        node.derived = 'UBER'
-                        # TODO: Read Alpha parameters from paths.json
-                        new_mat.alpha_threshold = node.alpha_test_value = 0.5
-                        new_mat.show_transparent_back = False
-                        node.alpha_mode = 'CLIP'
-                        if blender_version < 4.2:
-                            new_mat.blend_method = 'CLIP'
-                        else:
-                            new_mat.surface_render_method = "DITHERED"
+# ---------------------------------------------------------------------------
+# Orchestrator + Operator (spec §10)
+# ---------------------------------------------------------------------------
 
-                        mat_info = slot["mat_info"]
-                        other_values = mat_info['otherValues']
+def load(operator, context, filepath=""):
+    # type: (Any, Any, str) -> bool
+    """
+    Does the actual work of importing a Jedipedia-formatted NPC/Character
+    json file: parse -> import every slot's variants -> optionally import
+    a skeleton -> assemble Collections -> optionally bind to skeleton.
 
-                        img = path_split(mat_info["ddsPaths"]["diffuseMap"])
-                        if img in imgs:
-                            node.diffuseMap = imgs[img]
-                        else:
-                            node.diffuseMap = imgs.load(mat_info["ddsPaths"]["diffuseMap"])
+    Returns True on success, False on failure (mirrors import_gr2.py's
+    own load() return convention).
+    """
+    prefs = bpy.context.preferences.addons["io_scene_gr2"].preferences
+    resources_root = prefs.swtor_resources_dir
 
-                        img = path_split(mat_info["ddsPaths"]["rotationMap"])
-                        if img in imgs:
-                            node.rotationMap = imgs[img]
-                        else:
-                            node.rotationMap = imgs.load(mat_info["ddsPaths"]["rotationMap"])
+    if not resources_root or not Path(resources_root).is_dir():
+        operator.report(
+            {'ERROR'},
+            "Set a valid Resources Folder in IO Scene GR2's add-on preferences first.",
+        )
+        return False
 
-                        img = path_split(mat_info["ddsPaths"]["glossMap"])
-                        if img in imgs:
-                            node.glossMap = imgs[img]
-                        else:
-                            node.glossMap = imgs.load(mat_info["ddsPaths"]["glossMap"])
+    try:
+        meta, slots, skin_mats = read(filepath)
+    except (OSError, json.JSONDecodeError) as exc:
+        operator.report({'ERROR'}, "Couldn't read %s: %s" % (filepath, exc))
+        return False
 
-                mat_slot.material = new_mat
+    if not slots:
+        operator.report({'WARNING'}, "No recognizable slot entries found in this file.")
+        return False
+
+    npc_name = meta.get("charName") or Path(filepath).stem
+
+    job_results['job_origin'] = operator.bl_idname
+    if not operator.job_results_accumulate:
+        job_results['objs_names'] = []
+        job_results['files_objs_names'] = {}
+
+    slot_objects = {}
+    for slot_name, entries in slots.items():
+        objects_for_slot = []
+        for entry in entries:
+            objects_for_slot.extend(
+                import_variant(operator, context, resources_root, entry, skin_mats)
+            )
+        slot_objects[slot_name] = objects_for_slot
+
+    skeleton_ob = None
+    if operator.import_skeleton:
+        skeleton_ob = import_skeleton(operator, context, resources_root, meta)
+
+    if operator.correct_twilek_eyes_uv:
+        apply_twilek_eyes_uv_fix(slot_objects)
+
+    if operator.separate_eyes:
+        separate_head_eyes(slot_objects, operator.separate_each_eye)
+
+    assemble_collections(
+        context,
+        npc_name,
+        slot_objects,
+        skeleton_ob,
+        character_name_suffix=meta.get("charName") if operator.append_character_name_to_collections else None,
+    )
+
+    if operator.bind_to_skeleton and skeleton_ob is not None:
+        all_objects = [ob for objects in slot_objects.values() for ob in objects]
+        bind_objects_to_armature(all_objects, skeleton_ob)
 
     return True
 
 
-def load(operator, context, filepath=""):
-    # type: (Operator, Context, str) -> bool
-    
-    start_time = time.time()
-    
-    print( "----------")
-    print(f"JSON FILE: {filepath}")
-    print( "----------")
+class ImportCHA(bpy.types.Operator):
+    """
+    Import a Jedipedia.net-formatted NPC/Character json file.
 
-    slots, skin_mats = read(operator, filepath)
+    Reads .gr2, .mat, and .dds assets directly from the Resources Folder
+    configured in this add-on's Preferences -- no separate asset
+    gathering/copying step is needed.
+    """
+    bl_idname = "import_mesh.gr2_json"  # DO NOT CHANGE -- external tools call this by name
+    bl_label = "Import SWTOR NPC/Character (.json)"
+    bl_description = "Import a Jedipedia.net-formatted NPC/Character .json file"
+    bl_options = {'UNDO'}
 
+    filepath: bpy.props.StringProperty(subtype='FILE_PATH')
+    filter_glob: bpy.props.StringProperty(default="*.json", options={'HIDDEN'})
 
-    # This was originally a plain "if slots:", but Crunch discovered that
-    # exporting NPC JSON data from Jedipedia IN FIREFOX somehow eats the skinMats key.
-    # Also, stops Jedipedia needing to export the skinmats block for NPCS THAT DON'T HAVE SKINMATS.
-    # if slots:
-    if slots or skin_mats:
+    append_character_name_to_collections: bpy.props.BoolProperty(
+        name="Append Name to Collections",
+        description=(
+            "Appends the character's name to every per-slot Collection, "
+            "e.g. \"Boot\" -> \"Boot - Republic Officer\".\n\n"
+            "Only takes effect if the json's meta data actually includes "
+            "a character name -- has no effect otherwise"
+        ),
+        default=False,
+    )
 
-        if bpy.ops.object.mode_set.poll():
-            bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
+    npc_uses_skin: bpy.props.BoolProperty(
+        name="Gear Uses Skin",
+        description=(
+            "When importing a non-Creature-type characters, assume that any 2nd "
+            "Material Slot in armor or clothes is skin rather than "
+            "garment.\n\n"
+            "Typical case actually needing this: revealing clothing."
+        ),
+        default=True,
+    )
 
-        if build(operator, context, slots, skin_mats):
+    import_skeleton: bpy.props.BoolProperty(
+        name="Import Skeleton",
+        description="Imports the skeleton referenced by the json file's meta data, if present",
+        default=False,  # seeded from add-on Preferences in invoke()
+    )
 
-            elapsed_time = time.time() - start_time
-            print()
-            print()
-            print( "----------------------")
-            print(f"TOTAL PROCESSING TIME: {elapsed_time:.3f} s.")
-            print( "----------------------")
+    bind_to_skeleton: bpy.props.BoolProperty(
+        name="Bind To Skeleton",
+        description="Binds all imported objects to the imported skeleton via Armature modifiers",
+        default=False,  # seeded from add-on Preferences in invoke()
+    )
 
-            return True
+    correct_twilek_eyes_uv: bpy.props.BoolProperty(
+        name="Correct Twi'lek Eyes UV",
+        description="Corrects a known UV offset issue on Twi'lek eyes",
+        default=True,
+    )
 
-        return False
+    separate_eyes: bpy.props.BoolProperty(
+        name="Separate Eyes",
+        description="Separates the eyes from the head object into their own object, useful for rigging",
+        default=False,
+    )
+
+    separate_each_eye: bpy.props.BoolProperty(
+        name="Separate Eyes Individually",
+        description=(
+        "When separating eyes, makes each eye its own object with its own origin.\n\n"
+        "Requires \"Separate Eyes\" to be enabled as well."
+        ),
+        default=False,
+    )
+
+    job_results_rich: bpy.props.BoolProperty(
+        name="Rich Results Info",
+        options={'HIDDEN'},
+        default=False,
+    )
+
+    job_results_accumulate: bpy.props.BoolProperty(
+        name="Accumulate Jobs' Results Info",
+        options={'HIDDEN'},
+        default=True,
+    )
+
+    # Not exposed in the panel, and always False: import_gr2.py's load()
+    # reads this attribute unconditionally before it even checks
+    # bl_idname to decide where the *other* import settings come from,
+    # so it has to exist regardless. Unlike import_collision/
+    # name_as_filename/etc. (genuinely decorative for this operator,
+    # since those are always sourced from add-on Preferences instead),
+    # this one isn't optional to declare.
+    enforce_neutral_settings: bpy.props.BoolProperty(
+        options={'HIDDEN'},
+        default=False,
+    )
+
+    def invoke(self, context, event):
+        prefs = bpy.context.preferences.addons["io_scene_gr2"].preferences
+        self.import_skeleton = prefs.gr2_import_skeleton_default
+        self.bind_to_skeleton = prefs.gr2_bind_to_skeleton_default
+        self.append_character_name_to_collections = prefs.gr2_append_character_name_to_collections_default
+        context.window_manager.fileselect_add(self)
+        return {'RUNNING_MODAL'}
+
+    def execute(self, context):
+        if load(self, context, filepath=self.filepath):
+            return {'FINISHED'}
+        return {'CANCELLED'}

--- a/io_scene_gr2/ops/import_gr2.py
+++ b/io_scene_gr2/ops/import_gr2.py
@@ -704,6 +704,11 @@ def build(gr2,
         armature.name = filepath.split(os.sep)[-1][:-4]
         armature.display_type = 'STICK'
 
+        # Remove the default bone Blender auto-creates with object.add(type='ARMATURE'),
+        # otherwise every gr2 bone index below ends up off-by-one against armature.edit_bones.
+        for default_bone in list(armature.edit_bones):
+            armature.edit_bones.remove(default_bone)
+
         # Bones creation
         for bone in gr2.bone_buffer.values():
             new_bone = armature.edit_bones.new(bone.name)


### PR DESCRIPTION
Addon major version revision. Addon name change. Overhaul of 'JSON Character Importer' for new Format/Bug Fixes. Corrected skeleton,gr2 extra bone silent bug.

TL;DR: I've completely rebuilt Atroxa's JSON importer with C-3POs unknowing help (❤️). 
- File > Import is BACK, Baby. 
- Old TORC Exports will (probably) no longer work for both NPCs or Characters. I had considered keeping character compatability short term but the deafing silence of people offering up character files in Discord #extracting made me rip off the band-aid.
- NPCs from Jedipedia will soon (I have PR in for the export format change) include a new Meta block that has Skeleton Data and some other stuff. If I can work it out in the future include name data too - Although people can just enter that in manually if they wish - The importer will use the name for things(tm).
- The Importer can import without the meta block, but its a nice to have. It just gets upset with TORCs somewhat broken and incomplete format.
- All NPC types now correctly import. I got tried of fixing things like Dual Slot HQC NPCs half a dozen times so its now a permanant feature.
- All NPC variations now import. NPC has four randomized heads, hairs, or something else? They'll import as well. Multiple Skin Tones on single heads are not currently supported as Jedipedia doesn't export that.
- JSONs are all that is required for importing NPCs now. There is no longer a two step process of gathering files into dirs, then importing, the importer simply reads the JSON and runs off to the resources folder you set in the addon preferences menu and pulls it all together.
- Also added future planning for a legacy resources folder for crazies like Sultana and I who prefer the original materials for PC heads and bodies.
- Some random bone fix for the skeleton.gr2 import that I think was needed due to some weird index count error from blenders initial default bone.
- Probably other things I've forgotten.